### PR TITLE
Fixes for empatica issues.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,7 @@ android {
         versionName '1.0.2'
         manifestPlaceholders = ['appAuthRedirectScheme': 'org.radarbase.passive.app']
         multiDexEnabled true
+        // Comment the next line out for x86 emulator support. In that case, disable the Empatica plugin.
         ndk { abiFilters "armeabi", "armeabi-v7a" }
     }
     lintOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,7 @@ android {
         versionName '1.0.2'
         manifestPlaceholders = ['appAuthRedirectScheme': 'org.radarbase.passive.app']
         multiDexEnabled true
+        ndk { abiFilters "armeabi", "armeabi-v7a" }
     }
     lintOptions {
         abortOnError false

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -24,7 +24,13 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--keep public class * implements org.radarbase.android.device.DeviceServiceProvider
+-keep public class * implements org.radarbase.android.source.SourceProvider { *; }
+-keep class * implements org.radarbase.android.source.SourceManager { *; }
+-keep class com.empatica.empalink.delegate.** { *; }
+-keep class com.empatica.empalink.** { *; }
+
+-keep interface com.empatica.empalink.delegate.** { *; }
+-keep interface com.empatica.empalink.** { *; }
 
 # Native methods: https://www.guardsquare.com/en/products/proguard/manual/examples#native
 # note that <methods> means any method


### PR DESCRIPTION
- The current empatica lib does not support arm64 devices. So we set the ABI to only build targeting 32 bit for now (will work on 64 bit too)([ref](https://github.com/empatica/empalink-sample-project-android/issues/16)). Later we should plan to move to the new [empa Link SDK](https://developer.empatica.com/android-sdk-tutorial-100.html) which only supports 64 bit arch. The interface is mostly the same, only adds two more functions to implement in the delegate impls.
- Prevent empatica classes from being removed during build(adds progaurd rules) - fixes #103 

#### Also see - https://github.com/RADAR-base/radar-commons-android/pull/195