### PR TITLE
Separation of Redirects for LoginActivity into Distinct Intent-Filter Tags

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -96,7 +96,6 @@
                 <data
                     android:host="radar-base.org"
                     android:scheme="org.radarbase.prmt" />
-
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,7 +76,8 @@
             android:configChanges="keyboardHidden|orientation"
             android:screenOrientation="userPortrait"
             android:exported="true">
-            <intent-filter android:label="@string/filter_open_prmt" >
+            <intent-filter android:label="@string/filter_open_prmt"
+                android:autoVerify="true" >
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,16 +81,22 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <!-- Accepts URIs that begin with "http://www.example.com/gizmos” -->
+                <!-- Accepts URIs that begin with "http://www.radar-base.org/prmt/...” -->
                 <data
                     android:host="radar-base.org"
                     android:pathPrefix="/prmt"
                     android:scheme="https" />
-                <!-- note that the leading "/" is required for pathPrefix -->
-                <!-- Accepts URIs that begin with "example://gizmos” -->
+            </intent-filter>
+            <intent-filter android:label="@string/custom_filter_open_prmt">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <!-- Accepts URIs that begin with "radar-base.org://org.radarbase.prmt” -->
                 <data
                     android:host="radar-base.org"
                     android:scheme="org.radarbase.prmt" />
+
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="consent_collected_data"><![CDATA[I have read <b><u>Description of collected data</u></b> and agree to it.]]></string>
     <string name="consent_server"><![CDATA[I agree to send data to <b><u>%1$s</u></b>.]]></string>
     <string name="filter_open_prmt">Open RADAR pRMT</string>
+    <string name="custom_filter_open_prmt">Open pRMT Application</string>
     <string name="action_header">Actions</string>
     <string name="appUpdated">pRMT successfully updated</string>
     <string name="radar_cns_logo">RADAR-CNS logo</string>

--- a/app/src/selfRelease/AndroidManifest.xml
+++ b/app/src/selfRelease/AndroidManifest.xml
@@ -75,7 +75,8 @@
             android:configChanges="keyboardHidden|orientation"
             android:screenOrientation="userPortrait"
             android:exported="true">
-            <intent-filter android:label="@string/filter_open_prmt" >
+            <intent-filter android:label="@string/filter_open_prmt"
+                android:autoVerify="true" >
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -95,7 +96,6 @@
                 <data
                     android:host="radar-base.org"
                     android:scheme="org.radarbase.prmt" />
-
             </intent-filter>
         </activity>
         <activity

--- a/app/src/selfRelease/AndroidManifest.xml
+++ b/app/src/selfRelease/AndroidManifest.xml
@@ -80,16 +80,22 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <!-- Accepts URIs that begin with "http://www.example.com/gizmos” -->
+                <!-- Accepts URIs that begin with "http://www.radar-base.org/prmt/...” -->
                 <data
                     android:host="radar-base.org"
                     android:pathPrefix="/prmt"
                     android:scheme="https" />
-                <!-- note that the leading "/" is required for pathPrefix -->
-                <!-- Accepts URIs that begin with "example://gizmos” -->
+            </intent-filter>
+            <intent-filter android:label="@string/custom_filter_open_prmt">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <!-- Accepts URIs that begin with "radar-base.org://org.radarbase.prmt” -->
                 <data
                     android:host="radar-base.org"
                     android:scheme="org.radarbase.prmt" />
+
             </intent-filter>
         </activity>
         <activity


### PR DESCRIPTION
Currently, the redirects for the LoginActivity support one app link: `https://radar-base.org`
and one custom URI:`org.radarbase.prmt://radar-base.org`

These are declared as data tags within the same intent filter. However, according to [Android documentation](https://developer.android.com/training/app-links/deep-linking#:~:text=Notice%20that%20the,consider%20the%20following%3A), they should be specified in separate intent filters. Failing to do so results in a permutation of both data tags, leading to four unintended links.

